### PR TITLE
add yaml config and cycling through dates and sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# log files
+*.log

--- a/src/s3-copy.py
+++ b/src/s3-copy.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from datetime import datetime, timedelta
+import utils.time_utils as time_utils
+import yaml
+import sys
+
+#----- check the python version because this assumes we use ordered dictionaries
+assert sys.version_info >= (3, 6), "Requires python > 3.6"
+
+#----- load and parse yaml file
+yamlpath = '../test/testinput/s3_source.yaml'
+f = open(yamlpath)
+config_dict = yaml.safe_load(f)
+f.close()
+
+# read date range
+dr = time_utils.get_date_range_from_dict(config_dict.get('date_range'))
+# read cycling interval in seconds
+cycling_interval = config_dict.get('cycling_interval')
+# read source info
+sources = config_dict.get('source')
+
+#----- cycle through the date range
+while not(dr.at_end()):
+  current_cycle = dr.current
+  print(current_cycle)
+  dr.increment(seconds = cycling_interval)
+  #----- cycle through the sources
+  for source in sources.items():
+    source_name = source[1].get('name')
+    print(f"using {source_name} at time {current_cycle}")
+
+print('at the end of the time loop')
+
+

--- a/src/s3-copy.py
+++ b/src/s3-copy.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 import utils.time_utils as time_utils
+import utils.file_utils as file_utils
 import yaml
 import sys
 
@@ -9,7 +10,12 @@ import sys
 assert sys.version_info >= (3, 6), "Requires python > 3.6"
 
 #----- load and parse yaml file
-yamlpath = '../test/testinput/s3_source.yaml'
+#yamlpath = '../test/testinput/s3_source.yaml'
+assert len(sys.argv) == 2, "Config file not specified. Required calling sequence: s3-copy.py <config.yaml>"
+yamlpath = sys.argv[1]
+file_utils.is_valid_readable_file(yamlpath)
+
+
 f = open(yamlpath)
 config_dict = yaml.safe_load(f)
 f.close()

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+import re
+
+
+def is_valid_readable_file(filepath):
+    """
+    Method to ensure that the filename/path is valid, exists, contains data,
+    and the user has sufficient permissions to read it.
+    """
+    # look for invalid characters in filename/path
+    try:
+        m = re.search(r'[^A-Za-z0-9\._\-\/]', filepath)
+        if m is not None and m.group(0) is not None:
+            print(
+                'Only a-z A-Z 0-9 and - . / _ characters allowed in filepath')
+            raise ValueError(
+                f'Invalid characters found in file path: {filepath}')
+    except Exception as e:
+        raise ValueError(f'Invalid file path: {e}')
+    try:
+        path = Path(filepath)
+        if not path.is_file():
+            raise ValueError(f'Path: {filepath} does not exist')
+    except Exception as e:
+        raise ValueError(f'Invalid file path: {e}')
+
+    # check permissions on file
+    status = os.stat(filepath, follow_symlinks=True)
+    print(f'status.st_size: {status.st_size}')
+    if status.st_size == 0:
+        print(f'if block caught 0 byte file {status}')
+        raise ValueError(f'Invalid file. File {filepath} is empty.')
+
+    permissions = oct(status.st_mode)[-3:]
+    readAccess = os.access(filepath, os.R_OK)
+    if readAccess is False:
+        raise ValueError(
+            f'Insufficient permissions on file "{filepath}" - {permissions}.'
+        )

--- a/src/utils/time_utils.py
+++ b/src/utils/time_utils.py
@@ -1,0 +1,196 @@
+from datetime import datetime, timedelta
+from typing import Optional
+from dataclasses import dataclass
+
+
+SECONDS_IN_A_DAY = 24 * 3600
+
+DEFAULT_START_TIME = datetime(year=1990, month=1, day=1)
+DEFAULT_END_TIME = datetime.utcnow()
+DEFAULT_DATE_STR = '%Y%m%dT%H%M%SZ'
+DEFAULT_CYCLE_INTERVALS = [0, 21600, 43200, 64800]
+
+DEFAULT_DATE_RANGE_CONFIG = {
+    'datestr': DEFAULT_DATE_STR,
+    'start': DEFAULT_START_TIME,
+    'end': DEFAULT_END_TIME
+}
+
+DEFAULT_OBS_CYCLE_INTERVALS = [0, 3600*6, 3600*12, 3600*18]
+
+
+def default_datetime_converter(obj):
+   if isinstance(obj, datetime):
+      return obj.__str__()
+
+
+def get_datetime_str(value, format_str):
+    try:
+        formatted_datetime = datetime.strftime(value, format_str)
+    except Exception as e:
+        msg = f'Invalid time: {value} or format_str: {format_str}' \
+              f', error: {e}'
+        raise ValueError(msg)
+
+    return formatted_datetime
+
+def is_valid_increment_type(value):
+    if not isinstance(value, str) or value not in VALID_INCREMENT_TYPES:
+        return False
+    return True
+
+
+def set_datetime(time_str, format_str):
+    try:
+        time = datetime.strptime(time_str, format_str)
+        print(f'in set_datetime - time: {time}, time_str: {time_str}, format_str: {format_str}')
+    except Exception as e:
+        msg = f'Invalid time str: {time_str} or format string: {format_str}. {e}'
+        raise ValueError(msg)
+
+    return time
+
+
+def get_date_range_from_dict(date_range):
+    """
+    This method is expecting a dictionary with fields 'start', 'end', and
+    'datestr' where 'start' and 'end' are valid datetime strings and
+    'datestr' is a format string used to translate 'start' and 'end'
+    strings into valid datetime objects.
+    If the 'datestr' format string must be valid.
+    """
+    if not isinstance(date_range, dict):
+        msg = f'"date_range" must be a dict type, valid example: ' \
+              f'{DEFAULT_DATE_RANGE_CONFIG}, using defaults.'
+        raise ValueError(msg)
+
+    datestr = date_range.get('datestr')
+    try:
+        test_formatted_date = datetime.utcnow().strftime(datestr)
+    except Exception as e:
+        msg = f'Invalid date format string: {date_range}, valid example: ' \
+              f'{DEFAULT_DATE_STR}, error: {e}'
+        raise ValueError(msg)
+
+    raw_start = date_range.get('start')
+    raw_end = date_range.get('end')
+    start = set_datetime(raw_start, datestr)
+    end = set_datetime(raw_end, datestr)
+
+    if start is None:
+        start = DEFAULT_START_TIME
+        msg = f'Error: invalid start time: {raw_start}, using default: ' \
+              f'{DEFAULT_START_TIME}'
+        raise ValueError(msg)
+    
+    if end is None:
+        end = DEFAULT_END_TIME 
+        msg = f'Error: invalid end time: {raw_end}, using default: ' \
+              f'{DEFAULT_END_TIME}'
+        raise ValueError(msg)
+
+    print(f'start: {start}, end: {end}')
+
+    if start > end:
+        msg = f'Invalid date range: {date_range}, "start" must be older than ' \
+              f'"end", valid example: {DEFAULT_DATE_RANGE_CONFIG}'
+        raise ValueError(msg)
+
+    
+    return DateRange(start, end)
+
+
+
+@dataclass
+class DateRange:
+    start: Optional[datetime] = DEFAULT_START_TIME
+    end: Optional[datetime] = DEFAULT_END_TIME
+    current: datetime = None
+
+
+    def __post_init__(self):
+        if self.start > self.end:
+            msg = f'Invalid date range: "start": {self.start} must older than ' \
+                  f'"end": {self.end}.'
+            raise ValueError(msg)
+        self.current = self.start
+
+
+    def set_start(self, value):
+        if not isinstance(value, datetime):
+            msg = f'Invalid time {value} must be a valid datetime object.'
+            raise ValueError(msg)
+
+        self.start = value
+
+
+    def set_end(self, value):
+        if not isinstance(value, datetime):
+            msg = f'Invalid time {value} must be a valid datetime object.'
+            raise ValueError(msg)
+
+        if self.start > value:
+            msg = f'Start: {self.start} must be older than end: {value}'
+            raise ValueError(msg)
+
+        self.end = value
+
+
+    def set_current(self, value):
+        if not isinstance(value, datetime):
+            msg = f'Invalid time {value} must be a valid datetime object.'
+            raise ValueError(msg)
+
+        if (self.start > value or self.end < value):
+            msg = f'"current": {value} must be older than "end": {self.end} and' \
+                  f' newer than start: {self.start}'
+            raise ValueError(msg)
+
+        self.current = value
+
+
+    def increment(
+        self,
+        days=0,
+        seconds=0,
+        microseconds=0,
+        milliseconds=0,
+        minutes=0,
+        hours=0,
+        weeks=0
+    ):
+
+        new_time = self.current
+
+        try:
+            new_time += timedelta(
+                days,
+                seconds,
+                microseconds,
+                milliseconds,
+                minutes,
+                hours,
+                weeks
+            )
+        except Exception as e:
+            raise ValueError(f'Invalid timedelta: {e}')
+
+        if new_time < self.start:
+            self.current = self.start
+        elif new_time > self.end:
+            self.current = self.end
+        else:
+            self.current = new_time
+
+
+    def increment_day(self):    
+        self.increment(days=1)
+
+
+    def at_end(self):
+        return self.current == self.end
+
+
+    def at_start(self):
+        return self.current == self.start
+        

--- a/test/testinput/s3_source.yaml
+++ b/test/testinput/s3_source.yaml
@@ -1,0 +1,16 @@
+cycling_interval: 21600
+date_range:
+  datestr: '%Y%m%dT%H%M%SZ'
+  start: 19930101T000000Z
+  end: 19930102T060000Z 
+source:
+  -gefs:
+    name: gefs blend with errors
+    platform: aws_s3
+    key: observations/atmos/gefsv13_reanalysis-md5/%Y%m%d%H%M%S/bufr/
+    bucket: noaa-reanalyses-pds
+  -cfsr:
+    name: cfsr correction
+    platform: aws_s3
+    key: observations/atmos/gefsv13_reanalysis-md5/%Y%m%d%H%M%S/bufr/
+    bucket: noaa-reanalyses-pds


### PR DESCRIPTION
This adds a simple script driver that allows cycling through times and sources specified in the yaml file.

Question to reviewers. This is written in very simple python. Since this is my first medium-size python project, i decided to keep it simple. We can add classes or cli interface later as needed. However, if you guys have some suggestions on what would be appropriate at this time. I would be happy to incorporate. 

Also this code uses utils from one of the Steve Lawrence's projects. It has a nice interface that allows specifying date ranges. 

closes #2 